### PR TITLE
Adding coveralls support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,10 @@ go:
 before_install:
 - go get -d github.com/mattcunningham/haas-hall-lottery
 
+install:
+- go get golang.org/x/tools/cmd/cover
+- go get github.com/mattn/goveralls
+
 script:
 - go test -v ./...
+- $HOME/gopath/bin/goveralls  -service=travis-ci


### PR DESCRIPTION
This solves issue #5.

_Please discuss before answering._ There is some configuration on the coveralls.io website that deems a commit as a failure if it doesn't meet a certain standard of coverage.

I have it currently set as:
- 70% total coverage.
- A commit can't bring down the total project's coverage by _no more_ than 7%.

If that's good, go ahead and approve this.
